### PR TITLE
new line to add color to the node

### DIFF
--- a/src/models-map-to-dot.js
+++ b/src/models-map-to-dot.js
@@ -37,7 +37,7 @@ function modelsMapToDot(models, { hideEntityFields, dev } = {}) {
     } else {
       objects[modelName] = `"${modelName}" [label="{${dev ? `[${model.sys.id}] ${modelName}` : modelName} |          | ${fields.join('|').replace(/"/g, "'")}}" shape=Mrecord];`;
     }
-
+    objects[modelName] = model.isColored ? `node[style=filled, fillcolor = red, fontcolor= white] ${objects[modelName]} node[style=filled, fillcolor=white, fontcolor=black]` : objects[modelName];
     const rels = model.relations;
     // eslint-disable-next-line no-underscore-dangle
     if (rels._hasAssets) {


### PR DESCRIPTION
Se agregó linea para colorear el grafo.
Para colorear el grafo, basta con añadir la variable isColored para el elemento que se desea pintar. La funcion modelsMapToDot buscará este valor en cada elemento del objeto modelsMap que recibe por parámetro.